### PR TITLE
Fix missing default parameter in trackFade

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "GPStar Audio Serial Library",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "A serial communication control library for the GPStar Audio and GPStar Audio XL series of audio boards from GPStar Technologies.",
     "keywords": "audio, serial, music, wav",
     "authors":

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=GPStar Audio Serial Library
-version=1.3.0
+version=1.3.1
 author=Michael Rajotte
 license=GPL-3.0-or-later
 maintainer=Michael Rajotte <michael.rajotte@gpstartechnologies.com>

--- a/src/GPStarAudio.cpp
+++ b/src/GPStarAudio.cpp
@@ -476,7 +476,7 @@ void gpstarAudio::trackGain(uint16_t trk, int16_t gain) {
   GPStarSerial->write(txbuf, 9);
 }
 
-void gpstarAudio::trackFade(uint16_t trk, int16_t gain, uint16_t time, bool stopFlag) {
+void gpstarAudio::trackFade(uint16_t trk, int16_t gain, uint16_t time, bool stopFlag = false) {
   uint8_t txbuf[12];
 
   txbuf[0] = SOM1;

--- a/src/GPStarAudio.h
+++ b/src/GPStarAudio.h
@@ -106,7 +106,7 @@ public:
   void trackResume(uint16_t trk);
   void trackLoop(uint16_t trk, bool enable);
   void trackGain(uint16_t trk, int16_t gain);
-  void trackFade(uint16_t trk, int16_t gain, uint16_t time, bool stopFlag);
+  void trackFade(uint16_t trk, int16_t gain, uint16_t time, bool stopFlag = false);
   void samplerateOffset(int16_t offset);
   void setTriggerBank(uint8_t bank);
   void trackPlayingStatus(uint16_t trk);


### PR DESCRIPTION
The documentation states that the default value for stopFlag in trackFade should be false. This adds the missing default value for this parameter so that the code will match the documentation.

Also bumps the library version to 1.3.1 accordingly.